### PR TITLE
[PCT] Add Holy in White option to AoE advanced combo

### DIFF
--- a/XIVSlothCombo/Combos/JobHelpers/MNK.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/MNK.cs
@@ -5,6 +5,7 @@ using XIVSlothCombo.Combos.JobHelpers.Enums;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
+using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.JobHelpers
 {
@@ -15,7 +16,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
         {
             if (CustomComboFunctions.HasEffect(Buffs.OpoOpoForm) || CustomComboFunctions.HasEffect(Buffs.FormlessFist))
             {
-                if (Gauge.OpoOpoFury == 0)
+                if (Gauge.OpoOpoFury == 0 && DragonKick.LevelChecked())
                 {
                     if (CustomComboFunctions.LevelChecked(DragonKick))
                         return DragonKick;
@@ -28,7 +29,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
 
             if (CustomComboFunctions.HasEffect(Buffs.RaptorForm))
             {
-                if (Gauge.RaptorFury == 0)
+                if (Gauge.RaptorFury == 0 && TwinSnakes.LevelChecked())
                 {
                     if (CustomComboFunctions.LevelChecked(TwinSnakes))
                         return TwinSnakes;
@@ -42,7 +43,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
 
             if (CustomComboFunctions.HasEffect(Buffs.CoeurlForm))
             {
-                if (Gauge.CoeurlFury == 0)
+                if (Gauge.CoeurlFury == 0 && Demolish.LevelChecked())
                 {
                     if (!CustomComboFunctions.OnTargetsRear()
                         && CustomComboFunctions.TargetNeedsPositionals()

--- a/XIVSlothCombo/Combos/JobHelpers/RDM.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/RDM.cs
@@ -152,15 +152,6 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return true;
                 }
 
-                if (lastComboMove is Resolution
-                    && TraitLevelChecked(Traits.EnhancedManaficationIII)
-                    && HasEffect(Buffs.PrefulugenceReady))
-                {
-                    actionID = Prefulgence;
-                    return true;
-                }
-                    
-
                 actionID = 0;
                 return false;
             }
@@ -178,6 +169,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                 bool contra = SingleTarget ? Config.RDM_ST_oGCD_ContraSixte : Config.RDM_AoE_oGCD_ContraSixte;
                 bool engagement = SingleTarget ? Config.RDM_ST_oGCD_Engagement : Config.RDM_AoE_oGCD_Engagement;
                 bool vice = SingleTarget ? Config.RDM_ST_oGCD_ViceOfThorns : Config.RDM_AoE_oGCD_ViceOfThorns;
+                bool prefulg = SingleTarget ? Config.RDM_ST_oGCD_Prefulgence : Config.RDM_AoE_oGCD_Prefulgence;
                 int engagementPool = (SingleTarget && Config.RDM_ST_oGCD_Engagement_Pooling) || (!SingleTarget && Config.RDM_AoE_oGCD_Engagement_Pooling) ? 1 : 0;
 
                 bool corpacorps = SingleTarget ? Config.RDM_ST_oGCD_CorpACorps : Config.RDM_AoE_oGCD_CorpACorps;
@@ -219,6 +211,12 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     && TraitLevelChecked(Traits.EnhancedEmbolden)
                     && HasEffect(Buffs.ThornedFlourish))
                     placeOGCD = ViceOfThorns;
+
+                if (placeOGCD == 0 
+                    && prefulg
+                    && TraitLevelChecked(Traits.EnhancedManaficationIII)
+                    && HasEffect(Buffs.PrefulugenceReady))
+                    placeOGCD = Prefulgence;
 
                 if (CanSpellWeave(actionID) && placeOGCD != 0)
                 {

--- a/XIVSlothCombo/Combos/PvE/ALL.cs
+++ b/XIVSlothCombo/Combos/PvE/ALL.cs
@@ -76,7 +76,7 @@ namespace XIVSlothCombo.Combos.PvE
         public static bool CanUseLucid(uint actionID, int MPThreshold, bool weave = true) =>
             CustomComboFunctions.ActionReady(LucidDreaming)
             && CustomComboFunctions.LocalPlayer.CurrentMp <= MPThreshold
-            && (weave && CustomComboFunctions.CanSpellWeave(actionID));
+            && (!weave || CustomComboFunctions.CanSpellWeave(actionID));
 
         internal class ALL_IslandSanctuary_Sprint : CustomCombo
         {

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -514,21 +514,18 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Only check for our own HoTs
-                    var aspectedHeliosHoT = FindEffect(Buffs.AspectedHelios, LocalPlayer, LocalPlayer?.GameObjectId);
-                    var heliosConjunctionHoT = FindEffect(Buffs.HeliosConjunction, LocalPlayer, LocalPlayer?.GameObjectId);
+                    var hotCheck = HeliosConjuction.LevelChecked() ? FindEffect(Buffs.HeliosConjunction, LocalPlayer, LocalPlayer?.GameObjectId) : FindEffect(Buffs.AspectedHelios, LocalPlayer, LocalPlayer?.GameObjectId);
 
                     if ((IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) || // Helios mode: option must be on
                         !NonaspectedMode) // Aspected mode: option is not required
                     {
                         if ((ActionReady(AspectedHelios)
-                                 && aspectedHeliosHoT is null
-                                 && heliosConjunctionHoT is null)
+                                 && hotCheck is null)
                              || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
                             return OriginalHook(AspectedHelios);
                     }
 
-                    if ((aspectedHeliosHoT is not null || heliosConjunctionHoT is not null)
-                        && (aspectedHeliosHoT?.RemainingTime > 2 || heliosConjunctionHoT?.RemainingTime > 2))
+                    if (hotCheck is not null && hotCheck.RemainingTime > GetActionCastTime(OriginalHook(AspectedHelios)) + 1f)
                         return Helios;
                 }
 

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -186,26 +186,26 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(Starcross) &&
                             AnimationLock.CanDRGWeave(Starcross) &&
                             HasEffect(Buffs.StarcrossReady))
-                            return OriginalHook(Stardiver);
+                            return Starcross;
 
                         //Rise of the Dragon Feature
                         if (LevelChecked(RiseOfTheDragon) &&
                             AnimationLock.CanDRGWeave(RiseOfTheDragon) &&
                             HasEffect(Buffs.DragonsFlight))
-                            return OriginalHook(DragonfireDive);
-
-                        //Mirage Feature
-                        if (LevelChecked(MirageDive) &&
-                            AnimationLock.CanDRGWeave(MirageDive) &&
-                            HasEffect(Buffs.DiveReady))
-                            return OriginalHook(HighJump);
+                            return RiseOfTheDragon;
 
                         //Nastrond Feature
                         if (LevelChecked(Nastrond) &&
                             AnimationLock.CanDRGWeave(Nastrond) &&
                             HasEffect(Buffs.NastrondReady) &&
                             gauge.IsLOTDActive)
-                            return OriginalHook(Geirskogul);
+                            return Nastrond;
+
+                        //Mirage Feature
+                        if (LevelChecked(MirageDive) &&
+                            AnimationLock.CanDRGWeave(MirageDive) &&
+                            HasEffect(Buffs.DiveReady))
+                            return MirageDive;
                     }
 
                     //1-2-3 Combo
@@ -375,13 +375,13 @@ namespace XIVSlothCombo.Combos.PvE
                                 LevelChecked(Starcross) &&
                                 AnimationLock.CanDRGWeave(Starcross) &&
                                 HasEffect(Buffs.StarcrossReady))
-                                return OriginalHook(Stardiver);
+                                return Starcross;
 
                             //Rise of the Dragon Feature
                             if (IsEnabled(CustomComboPreset.DRG_ST_Dives_RiseOfTheDragon) &&
                                 AnimationLock.CanDRGWeave(RiseOfTheDragon) &&
                                 HasEffect(Buffs.DragonsFlight))
-                                return OriginalHook(DragonfireDive);
+                                return RiseOfTheDragon;
 
                             //Nastrond Feature
                             if (IsEnabled(CustomComboPreset.DRG_ST_Nastrond) &&
@@ -389,14 +389,14 @@ namespace XIVSlothCombo.Combos.PvE
                                 AnimationLock.CanDRGWeave(Nastrond) &&
                                 HasEffect(Buffs.NastrondReady) &&
                                 gauge.IsLOTDActive)
-                                return OriginalHook(Geirskogul);
+                                return Nastrond;
 
                             //Mirage Feature
                             if (IsEnabled(CustomComboPreset.DRG_ST_Mirage) &&
                                 LevelChecked(MirageDive) &&
                                 AnimationLock.CanDRGWeave(MirageDive) &&
                                 HasEffect(Buffs.DiveReady))
-                                return OriginalHook(HighJump);
+                                return MirageDive;
                         }
                     }
 

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -214,9 +214,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
                         {
                             return (LevelChecked(Disembowel) &&
-                                ((ChaosDoTDebuff is null) || GetBuffRemainingTime(Buffs.PowerSurge) < 15))
-                                ? OriginalHook(Disembowel)
-                                : OriginalHook(VorpalThrust);
+                                 (((ChaosDoTDebuff is null) && LevelChecked(ChaosThrust)) ||
+                                 GetBuffRemainingTime(Buffs.PowerSurge) < 15))
+                                 ? OriginalHook(Disembowel)
+                                 : OriginalHook(VorpalThrust);
                         }
 
                         if (lastComboMove == OriginalHook(Disembowel) && LevelChecked(ChaosThrust))
@@ -415,7 +416,8 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
                         {
                             return (LevelChecked(Disembowel) &&
-                                 ((ChaosDoTDebuff is null) || GetBuffRemainingTime(Buffs.PowerSurge) < 15))
+                                 (((ChaosDoTDebuff is null) && LevelChecked(ChaosThrust)) ||
+                                 GetBuffRemainingTime(Buffs.PowerSurge) < 15))
                                  ? OriginalHook(Disembowel)
                                  : OriginalHook(VorpalThrust);
                         }

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -334,7 +334,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     //Ranged Uptime
-                    if (IsEnabled(CustomComboPreset.GNB_ST_RangedUptime) && 
+                    if (IsEnabled(CustomComboPreset.GNB_ST_RangedUptime) &&
                         !InMeleeRange() && LevelChecked(LightningShot) && HasBattleTarget())
                         return LightningShot;
 
@@ -378,7 +378,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             //Bloodfest
                             if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && ActionReady(Bloodfest) && Ammo is 0 && (JustUsed(NoMercy, 20f)))
-                                    return Bloodfest;
+                                return Bloodfest;
 
                             //Zone
                             if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && ActionReady(DangerZone) && !JustUsed(NoMercy))
@@ -441,7 +441,7 @@ namespace XIVSlothCombo.Combos.PvE
                         //Lv90-Lv99
                         if (!LevelChecked(ReignOfBeasts) && LevelChecked(DoubleDown))
                         {
-                            if (JustUsed(NoMercy, 3f) && 
+                            if (JustUsed(NoMercy, 3f) &&
                                 ((!HasEffect(Buffs.ReadyToBlast) && Ammo == 3 && bfCD < GCD * 12 || ActionReady(Bloodfest)) //2min
                                 || (bfCD is < 90 and > 15 && Ammo == 3) //1min 3 carts
                                 || (JustUsed(Bloodfest, 2f) && JustUsed(BrutalShell)))) //opener
@@ -833,24 +833,17 @@ namespace XIVSlothCombo.Combos.PvE
                         //DoubleDown
                         if (Ammo >= 2 && ActionReady(DoubleDown) && HasEffect(Buffs.NoMercy)) //use on CD under NM
                             return DoubleDown;
+                        //Reign
+                        if (LevelChecked(ReignOfBeasts)) //because leaving this out anywhere is a waste
+                        {
+                            if ((GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0) ||
+                                (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood)))
+                                return OriginalHook(ReignOfBeasts);
+                        }
                         //FatedCircle
                         if (Ammo > 0 && LevelChecked(FatedCircle) && (HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0) || //use when under NM after DD & ignores GF
                             (bfCD < 6)) // Bloodfest prep
                             return FatedCircle;
-                        //Reign
-                        if (LevelChecked(ReignOfBeasts)) //because leaving this out anywhere is a waste
-                        {
-                            if (GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0)
-                            {
-                                if (JustUsed(WickedTalon) || (JustUsed(EyeGouge)))
-                                    return OriginalHook(ReignOfBeasts);
-                            }
-
-                            if (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood))
-                            {
-                                return OriginalHook(ReignOfBeasts);
-                            }
-                        }
                     }
 
                     //1-2
@@ -893,7 +886,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 IsEnabled(Variant.VariantSpiritDart) &&
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                 return Variant.VariantSpiritDart;
-                            
+
                             //Variant Ultimatum
                             if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && ActionReady(Variant.VariantUltimatum))
                                 return Variant.VariantUltimatum;
@@ -921,24 +914,17 @@ namespace XIVSlothCombo.Combos.PvE
                         //DoubleDown
                         if (IsEnabled(CustomComboPreset.GNB_AoE_DoubleDown) && Ammo >= 2 && ActionReady(DoubleDown) && HasEffect(Buffs.NoMercy)) //use on CD under NM
                             return DoubleDown;
+                        //Reign
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_Reign) && LevelChecked(ReignOfBeasts)) //because leaving this out anywhere is a waste
+                        {
+                            if ((GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0) ||
+                                (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood)))
+                                return OriginalHook(ReignOfBeasts);
+                        }
                         //FatedCircle
                         if (Ammo > 0 && LevelChecked(FatedCircle) && ((IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0) || //use when under NM after DD & ignores GF
                             (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && bfCD < 6))) // Bloodfest prep
                             return FatedCircle;
-                        //Reign
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Reign) && LevelChecked(ReignOfBeasts)) //because leaving this out anywhere is a waste
-                        {
-                            if (GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0)
-                            {
-                                if (JustUsed(WickedTalon) || (JustUsed(EyeGouge)))
-                                    return OriginalHook(ReignOfBeasts);
-                            }
-
-                            if (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood))
-                            {
-                                return OriginalHook(ReignOfBeasts);
-                            }
-                        }
                     }
 
                     //1-2
@@ -1045,7 +1031,6 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(GnashingFang) && !ActionReady(DoubleDown) && GunStep == 0)
                             {
-                                if (JustUsed(WickedTalon) || (JustUsed(EyeGouge)))
                                     return OriginalHook(ReignOfBeasts);
                             }
 

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -840,16 +840,33 @@ namespace XIVSlothCombo.Combos.PvE
                                 (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood)))
                                 return OriginalHook(ReignOfBeasts);
                         }
-                        //FatedCircle
-                        if (Ammo > 0 && LevelChecked(FatedCircle) && (HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0) || //use when under NM after DD & ignores GF
+                        //FatedCircle - if not unlocked, use BurstStrike
+                        if (Ammo > 0 && LevelChecked(FatedCircle) && 
+                            (HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0) || //use when under NM after DD & ignores GF
                             (bfCD < 6)) // Bloodfest prep
                             return FatedCircle;
+                        if (Ammo > 0 && !LevelChecked(FatedCircle) && LevelChecked(BurstStrike) &&
+                            (HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0)) //use when under NM after DD & ignores GF
+                            return BurstStrike;
                     }
 
                     //1-2
-                    if (comboTime > 0 && lastComboMove == DemonSlice && LevelChecked(DemonSlaughter))
+                    if (comboTime > 0)
                     {
-                        return (LevelChecked(FatedCircle) && Ammo == MaxCartridges(level)) ? FatedCircle : DemonSlaughter;
+                        if (lastComboMove == DemonSlice && LevelChecked(DemonSlaughter))
+                        {
+                            if (Ammo == MaxCartridges(level))
+                            {
+                                if (LevelChecked(FatedCircle))
+                                    return FatedCircle;
+                                if (!LevelChecked(FatedCircle))
+                                    return BurstStrike;
+                            }
+                            if (Ammo != MaxCartridges(level))
+                            {
+                                return DemonSlaughter;
+                            }
+                        }
                     }
 
                     return DemonSlice;
@@ -921,16 +938,33 @@ namespace XIVSlothCombo.Combos.PvE
                                 (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood)))
                                 return OriginalHook(ReignOfBeasts);
                         }
-                        //FatedCircle
-                        if (Ammo > 0 && LevelChecked(FatedCircle) && ((IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0) || //use when under NM after DD & ignores GF
+                        //FatedCircle - if not unlocked, use BurstStrike
+                        if (Ammo > 0 && LevelChecked(FatedCircle) && 
+                            ((IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0) || //use when under NM after DD & ignores GF
                             (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && bfCD < 6))) // Bloodfest prep
                             return FatedCircle;
+                        if (Ammo > 0 && !LevelChecked(FatedCircle) && LevelChecked(BurstStrike) &&
+                            (HasEffect(Buffs.NoMercy) && GunStep == 0)) // Bloodfest prep
+                            return BurstStrike;
                     }
 
                     //1-2
-                    if (comboTime > 0 && lastComboMove == DemonSlice && LevelChecked(DemonSlaughter))
+                    if (comboTime > 0)
                     {
-                        return (IsEnabled(CustomComboPreset.GNB_AoE_Overcap) && LevelChecked(FatedCircle) && Ammo == MaxCartridges(level)) ? FatedCircle : DemonSlaughter;
+                        if (lastComboMove == DemonSlice && LevelChecked(DemonSlaughter))
+                        {
+                            if (Ammo == MaxCartridges(level))
+                            {
+                                if (LevelChecked(FatedCircle))
+                                    return FatedCircle;
+                                if (!LevelChecked(FatedCircle))
+                                    return BurstStrike;
+                            }
+                            if (Ammo != MaxCartridges(level))
+                            {
+                                return DemonSlaughter;
+                            }
+                        }
                     }
 
                     return DemonSlice;

--- a/XIVSlothCombo/Combos/PvE/MNK.cs
+++ b/XIVSlothCombo/Combos/PvE/MNK.cs
@@ -294,13 +294,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (IsEnabled(CustomComboPreset.MNK_STUseBuffs))
                         {
-                            if (Brotherhood.LevelChecked()
+                            if (IsEnabled(CustomComboPreset.MNK_STUseBrotherhood) 
+                                && Brotherhood.LevelChecked()
                                 && !IsOnCooldown(Brotherhood))
                             {
                                 return Brotherhood;
                             }
 
-                            if (RiddleOfFire.LevelChecked()
+                            if (IsEnabled(CustomComboPreset.MNK_STUseROF) 
+                                && RiddleOfFire.LevelChecked()
                                 && !IsOnCooldown(RiddleOfFire))
                             {
                                 return RiddleOfFire;

--- a/XIVSlothCombo/Combos/PvE/MNK.cs
+++ b/XIVSlothCombo/Combos/PvE/MNK.cs
@@ -111,7 +111,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // OGCDs
-                    if (inCombat && canWeave)
+                    if (canWeave)
                     {
                         if (IsEnabled(Variant.VariantRampart) &&
                             IsOffCooldown(Variant.VariantRampart))
@@ -157,80 +157,79 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // GCDs
-                    if (inCombat)
+
+                    // Ensure usage if buff is almost depleted.
+                    if (HasEffect(Buffs.FiresRumination) && GetBuffRemainingTime(Buffs.FiresRumination) < 4)
                     {
-                        // Ensure usage if buff is almost depleted.
-                        if (HasEffect(Buffs.FiresRumination) && GetBuffRemainingTime(Buffs.FiresRumination) < 4)
-                        {
-                            return FiresReply;
-                        }
+                        return FiresReply;
+                    }
 
-                        if (HasEffect(Buffs.WindsRumination) && GetBuffRemainingTime(Buffs.WindsRumination) < 4)
-                        {
-                            return WindsReply;
-                        }
+                    if (HasEffect(Buffs.WindsRumination) && GetBuffRemainingTime(Buffs.WindsRumination) < 4)
+                    {
+                        return WindsReply;
+                    }
 
-                        if (HasEffect(Buffs.FormlessFist))
-                        {
-                            return Gauge.OpoOpoFury == 0 ? OriginalHook(DragonKick) : OriginalHook(Bootshine);
-                        }
+                    if (HasEffect(Buffs.FormlessFist))
+                    {
+                        return Gauge.OpoOpoFury == 0 ? OriginalHook(DragonKick) : OriginalHook(Bootshine);
+                    }
 
-                        // Masterful Blitz
-                        if (MasterfulBlitz.LevelChecked() && !HasEffect(Buffs.PerfectBalance) && HasEffect(Buffs.RiddleOfFire) && !IsOriginal(MasterfulBlitz))
-                        {
-                            return OriginalHook(MasterfulBlitz);
-                        }
+                    // Masterful Blitz
+                    if (MasterfulBlitz.LevelChecked() && !HasEffect(Buffs.PerfectBalance) && HasEffect(Buffs.RiddleOfFire) && !IsOriginal(MasterfulBlitz))
+                    {
+                        return OriginalHook(MasterfulBlitz);
+                    }
 
-                        // Perfect Balance
-                        if (HasEffect(Buffs.PerfectBalance))
-                        {
-                            bool solarNadi = Gauge.Nadi == Nadi.SOLAR;
-                            bool lunarNadi = Gauge.Nadi == Nadi.LUNAR;
-                            int opoOpoChakra = Gauge.BeastChakra.Where(x => x == BeastChakra.OPOOPO).Count();
-                            int raptorChakra = Gauge.BeastChakra.Where(x => x == BeastChakra.RAPTOR).Count();
-                            int coeurlChakra = Gauge.BeastChakra.Where(x => x == BeastChakra.COEURL).Count();
+                    // Perfect Balance
+                    if (HasEffect(Buffs.PerfectBalance))
+                    {
+                        bool solarNadi = Gauge.Nadi == Nadi.SOLAR;
+                        bool lunarNadi = Gauge.Nadi == Nadi.LUNAR;
+                        int opoOpoChakra = Gauge.BeastChakra.Where(x => x == BeastChakra.OPOOPO).Count();
+                        int raptorChakra = Gauge.BeastChakra.Where(x => x == BeastChakra.RAPTOR).Count();
+                        int coeurlChakra = Gauge.BeastChakra.Where(x => x == BeastChakra.COEURL).Count();
 
-                            #region Open Solar
-                            if (!solarNadi && !bothNadisOpen)
+                        #region Open Solar
+                        if (!solarNadi && !bothNadisOpen)
+                        {
+                            if (coeurlChakra == 0)
                             {
-                                if (coeurlChakra == 0)
-                                {
-                                    return Gauge.CoeurlFury == 0 ? OriginalHook(Demolish) : OriginalHook(SnapPunch);
-                                }
-                                else if (raptorChakra == 0)
-                                {
-                                    return Gauge.RaptorFury == 0 ? OriginalHook(TwinSnakes) : OriginalHook(TrueStrike);
-                                }
-                                else if (opoOpoChakra == 0)
-                                {
-                                    return Gauge.OpoOpoFury == 0 ? OriginalHook(DragonKick) : OriginalHook(Bootshine);
-                                }
+                                return Gauge.CoeurlFury == 0 ? OriginalHook(Demolish) : OriginalHook(SnapPunch);
                             }
-                            #endregion
-                            #region Open Lunar
-                            if (solarNadi || lunarNadi || bothNadisOpen)
+                            else if (raptorChakra == 0)
+                            {
+                                return Gauge.RaptorFury == 0 ? OriginalHook(TwinSnakes) : OriginalHook(TrueStrike);
+                            }
+                            else if (opoOpoChakra == 0)
                             {
                                 return Gauge.OpoOpoFury == 0 ? OriginalHook(DragonKick) : OriginalHook(Bootshine);
                             }
-                            #endregion
                         }
-
-                        if (HasEffect(Buffs.WindsRumination))
+                        #endregion
+                        #region Open Lunar
+                        if (solarNadi || lunarNadi || bothNadisOpen)
                         {
-                            return WindsReply;
+                            return Gauge.OpoOpoFury == 0 ? OriginalHook(DragonKick) : OriginalHook(Bootshine);
                         }
-
-                        if (HasEffect(Buffs.FiresRumination)
-                            && !HasEffect(Buffs.PerfectBalance)
-                            && !HasEffect(Buffs.FormlessFist)
-                            && (WasLastWeaponskill(LeapingOpo) || WasLastWeaponskill(DragonKick)))
-                        {
-                            return FiresReply;
-                        }
-
-                        // Standard Beast Chakras
-                        return MNKHelper.DetermineCoreAbility(actionID);
+                        #endregion
                     }
+
+                    if (HasEffect(Buffs.WindsRumination))
+                    {
+                        return WindsReply;
+                    }
+
+                    if (HasEffect(Buffs.FiresRumination)
+                        && !HasEffect(Buffs.PerfectBalance)
+                        && !HasEffect(Buffs.FormlessFist)
+                        && (WasLastWeaponskill(LeapingOpo) || WasLastWeaponskill(DragonKick)))
+                    {
+                        return FiresReply;
+                    }
+
+                    // Standard Beast Chakras
+                    return MNKHelper.DetermineCoreAbility(actionID);
+
                 }
 
                 return actionID;
@@ -468,7 +467,7 @@ namespace XIVSlothCombo.Combos.PvE
                             // 3. During Brotherhood.
                             // 4. During Riddle of Fire.
                             // 5. Prepare Masterful Blitz for the Riddle of Fire & Brotherhood window.
-                            if (HasCharges(PerfectBalance) && 
+                            if (HasCharges(PerfectBalance) &&
                                 (GetRemainingCharges(PerfectBalance) == GetMaxCharges(PerfectBalance)) ||
                                 (GetCooldownRemainingTime(PerfectBalance) <= 4) ||
                                 (HasEffect(Buffs.Brotherhood)) ||

--- a/XIVSlothCombo/Combos/PvE/RDM.cs
+++ b/XIVSlothCombo/Combos/PvE/RDM.cs
@@ -108,6 +108,7 @@ namespace XIVSlothCombo.Combos.PvE
                 RDM_ST_oGCD_CorpACorps_Melee = new("RDM_ST_oGCD_CorpACorps_Melee"),
                 RDM_ST_oGCD_CorpACorps_Pooling = new("RDM_ST_oGCD_CorpACorps_Pooling"),
                 RDM_ST_oGCD_ViceOfThorns = new("RDM_ST_oGCD_ViceOfThorns"),
+                RDM_ST_oGCD_Prefulgence = new("RDM_ST_oGCD_Prefulgence"),
                 RDM_ST_MeleeCombo_Adv = new("RDM_ST_MeleeCombo_Adv"),
                 RDM_ST_MeleeFinisher_Adv = new("RDM_ST_MeleeFinisher_Adv"),
                 RDM_ST_MeleeEnforced = new("RDM_ST_MeleeEnforced"),
@@ -121,6 +122,7 @@ namespace XIVSlothCombo.Combos.PvE
                 RDM_AoE_oGCD_CorpACorps_Melee = new("RDM_AoE_oGCD_CorpACorps_Melee"),
                 RDM_AoE_oGCD_CorpACorps_Pooling = new("RDM_AoE_oGCD_CorpACorps_Pooling"),
                 RDM_AoE_oGCD_ViceOfThorns = new("RDM_AoE_oGCD_ViceOfThorns"),
+                RDM_AoE_oGCD_Prefulgence = new("RDM_AoE_oGCD_Prefulgence"),
                 RDM_AoE_MeleeCombo_Adv = new("RDM_AoE_MeleeCombo_Adv"),
                 RDM_AoE_MeleeFinisher_Adv = new("RDM_AoE_MeleeFinisher_Adv");
             public static UserBoolArray

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -495,9 +495,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Aetherflow;
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp < Config.SCH_AoE_Heal_LucidOption)
+                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid)
+                        && All.CanUseLucid(actionID, Config.SCH_AoE_Heal_LucidOption, true))
                         return All.LucidDreaming;
 
                     // Indomitability

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -432,7 +432,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     //Reawakend Usage
-                    if (UseReawaken(gauge))
+                    if (IsEnabled(CustomComboPreset.VPR_ST_Reawaken) && UseReawaken(gauge))
                         return Reawaken;
 
                     //Overcap protection

--- a/XIVSlothCombo/Window/Functions/Presets.cs
+++ b/XIVSlothCombo/Window/Functions/Presets.cs
@@ -1,38 +1,77 @@
 ﻿using Dalamud.Interface.Colors;
 using Dalamud.Interface.Components;
+using Dalamud.Interface.Utility;
+using Dalamud.Interface.Utility.Raii;
 using Dalamud.Utility;
 using ECommons.DalamudServices;
 using ECommons.ImGuiMethods;
 using ImGuiNET;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using System.Reflection.Emit;
 using System.Text;
 using XIVSlothCombo.Attributes;
 using XIVSlothCombo.Combos;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.Data;
-using XIVSlothCombo.Extensions;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Window.Functions
 {
     internal class Presets : ConfigWindow
     {
+        internal static Dictionary<CustomComboPreset, PresetAttributes> Attributes = new();
+        internal class PresetAttributes
+        {
+            public bool IsPvP;
+            public CustomComboPreset[] Conflicts;
+            public CustomComboPreset? Parent;
+            public BlueInactiveAttribute? BlueInactive;
+            public VariantParentAttribute? VariantParent;
+            public BozjaParentAttribute? BozjaParent;
+            public EurekaParentAttribute? EurekaParent;
+            public HoverInfoAttribute? HoverInfo;
+            public ReplaceSkillAttribute? ReplaceSkill;
+            public CustomComboInfoAttribute? CustomComboInfo;
+
+            public PresetAttributes(CustomComboPreset preset)
+            {
+                IsPvP = PresetStorage.IsPvP(preset);
+                Conflicts = PresetStorage.GetConflicts(preset);
+                Parent = PresetStorage.GetParent(preset);
+                BlueInactive = preset.GetAttribute<BlueInactiveAttribute>();
+                VariantParent = preset.GetAttribute<VariantParentAttribute>();
+                BozjaParent = preset.GetAttribute<BozjaParentAttribute>();
+                EurekaParent = preset.GetAttribute<EurekaParentAttribute>();
+                HoverInfo = preset.GetAttribute<HoverInfoAttribute>();
+                ReplaceSkill = preset.GetAttribute<ReplaceSkillAttribute>();
+                CustomComboInfo = preset.GetAttribute<CustomComboInfoAttribute>();
+            }
+        }
+
         internal unsafe static void DrawPreset(CustomComboPreset preset, CustomComboInfoAttribute info, ref int i)
         {
+            if (!Attributes.ContainsKey(preset))
+            {
+                PresetAttributes attributes = new(preset);
+                Attributes[preset] = attributes;
+            }
             var enabled = PresetStorage.IsEnabled(preset);
-            var secret = PresetStorage.IsPvP(preset);
-            var conflicts = PresetStorage.GetConflicts(preset);
-            var parent = PresetStorage.GetParent(preset);
-            var blueAttr = preset.GetAttribute<BlueInactiveAttribute>();
+            var secret = Attributes[preset].IsPvP;
+            var conflicts = Attributes[preset].Conflicts;
+            var parent = Attributes[preset].Parent;
+            var blueAttr = Attributes[preset].BlueInactive;
+            var variantParents = Attributes[preset].VariantParent;
+            var bozjaParents = Attributes[preset].BozjaParent;
+            var eurekaParents = Attributes[preset].EurekaParent;
 
             ImGui.Spacing();
 
-            if (ImGui.Checkbox($"{info.FancyName}###{info.FancyName}{i}", ref enabled))
+            if (ImGui.Checkbox($"{info.FancyName}###{i}", ref enabled))
             {
                 if (enabled)
                 {
-
                     EnableParentPresets(preset);
                     Service.Configuration.EnabledActions.Add(preset);
                     foreach (var conflict in conflicts)
@@ -40,7 +79,6 @@ namespace XIVSlothCombo.Window.Functions
                         Service.Configuration.EnabledActions.Remove(conflict);
                     }
                 }
-
                 else
                 {
                     Service.Configuration.EnabledActions.Remove(preset);
@@ -49,34 +87,33 @@ namespace XIVSlothCombo.Window.Functions
                 Service.Configuration.Save();
             }
 
-            ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudGrey);
-
             DrawReplaceAttribute(preset);
 
             Vector2 length = new();
-
-            if (i != -1)
+            using (var styleCol = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudGrey))
             {
-                ImGui.Text($"#{i}: ");
-                length = ImGui.CalcTextSize($"#{i}: ");
-                ImGui.SameLine();
-                ImGui.PushItemWidth(length.Length());
-            }
-
-            ImGui.TextWrapped($"{info.Description}");
-
-            if (preset.GetHoverAttribute() != null)
-            {
-                if (ImGui.IsItemHovered())
+                if (i != -1)
                 {
-                    ImGui.BeginTooltip();
-                    ImGui.TextUnformatted(preset.GetHoverAttribute().HoverText);
-                    ImGui.EndTooltip();
+                    ImGui.Text($"#{i}: ");
+                    length = ImGui.CalcTextSize($"#{i}: ");
+                    ImGui.SameLine();
+                    ImGui.PushItemWidth(length.Length());
+                }
+
+                ImGui.TextWrapped($"{info.Description}");
+
+                if (Attributes[preset].HoverInfo != null)
+                {
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.BeginTooltip();
+                        ImGui.TextUnformatted(Attributes[preset].HoverInfo.HoverText);
+                        ImGui.EndTooltip();
+                    }
                 }
             }
 
 
-            ImGui.PopStyleColor();
             ImGui.Spacing();
 
             if (conflicts.Length > 0)
@@ -86,15 +123,18 @@ namespace XIVSlothCombo.Window.Functions
                 ImGui.Indent();
                 foreach (var conflict in conflicts)
                 {
-                    var comboInfo = conflict.GetAttribute<CustomComboInfoAttribute>();
+                    var comboInfo = Attributes.ContainsKey(conflict) ? Attributes[conflict].CustomComboInfo : conflict.GetAttribute<CustomComboInfoAttribute>();
                     conflictBuilder.Insert(0, $"{comboInfo.FancyName}");
                     var par2 = conflict;
 
                     while (PresetStorage.GetParent(par2) != null)
                     {
                         var subpar = PresetStorage.GetParent(par2);
-                        conflictBuilder.Insert(0, $"{subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName} -> ");
-                        par2 = subpar!.Value;
+                        if (subpar != null)
+                        {
+                            conflictBuilder.Insert(0, $"{(Attributes.ContainsKey(subpar.Value) ? Attributes[subpar.Value].CustomComboInfo : subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName)} -> ");
+                            par2 = subpar!.Value;
+                        }
 
                     }
 
@@ -125,21 +165,23 @@ namespace XIVSlothCombo.Window.Functions
                 }
             }
 
-            VariantParentAttribute? varientparents = preset.GetAttribute<VariantParentAttribute>();
-            if (varientparents is not null)
+            if (variantParents is not null)
             {
                 ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
-                ImGui.TextWrapped($"Part of normal combo{(varientparents.ParentPresets.Length > 1 ? "s" : "")}:");
+                ImGui.TextWrapped($"Part of normal combo{(variantParents.ParentPresets.Length > 1 ? "s" : "")}:");
                 StringBuilder builder = new();
-                foreach (var par in varientparents.ParentPresets)
+                foreach (var par in variantParents.ParentPresets)
                 {
-                    builder.Insert(0, $"{par.GetAttribute<CustomComboInfoAttribute>().FancyName}");
+                    builder.Insert(0, $"{(Attributes.ContainsKey(par) ? Attributes[par].CustomComboInfo.FancyName : par.GetAttribute<CustomComboInfoAttribute>().FancyName)}");
                     var par2 = par;
                     while (PresetStorage.GetParent(par2) != null)
                     {
                         var subpar = PresetStorage.GetParent(par2);
-                        builder.Insert(0, $"{subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName} -> ");
-                        par2 = subpar!.Value;
+                        if (subpar != null)
+                        {
+                            builder.Insert(0, $"{(Attributes.ContainsKey(subpar.Value) ? Attributes[subpar.Value].CustomComboInfo.FancyName : subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName)} -> ");
+                            par2 = subpar!.Value;
+                        }
 
                     }
 
@@ -149,21 +191,23 @@ namespace XIVSlothCombo.Window.Functions
                 ImGui.PopStyleColor();
             }
 
-            BozjaParentAttribute? bozjaparents = preset.GetAttribute<BozjaParentAttribute>();
-            if (bozjaparents is not null)
+            if (bozjaParents is not null)
             {
                 ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
-                ImGui.TextWrapped($"Part of normal combo{(varientparents.ParentPresets.Length > 1 ? "s" : "")}:");
+                ImGui.TextWrapped($"Part of normal combo{(variantParents.ParentPresets.Length > 1 ? "s" : "")}:");
                 StringBuilder builder = new();
-                foreach (var par in bozjaparents.ParentPresets)
+                foreach (var par in bozjaParents.ParentPresets)
                 {
-                    builder.Insert(0, $"{par.GetAttribute<CustomComboInfoAttribute>().FancyName}");
+                    builder.Insert(0, $"{(Attributes.ContainsKey(par) ? Attributes[par].CustomComboInfo.FancyName : par.GetAttribute<CustomComboInfoAttribute>().FancyName)}");
                     var par2 = par;
                     while (PresetStorage.GetParent(par2) != null)
                     {
                         var subpar = PresetStorage.GetParent(par2);
-                        builder.Insert(0, $"{subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName} -> ");
-                        par2 = subpar!.Value;
+                        if (subpar != null)
+                        {
+                            builder.Insert(0, $"{(Attributes.ContainsKey(subpar.Value) ? Attributes[subpar.Value].CustomComboInfo.FancyName : subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName)} -> ");
+                            par2 = subpar!.Value;
+                        }
 
                     }
 
@@ -173,21 +217,23 @@ namespace XIVSlothCombo.Window.Functions
                 ImGui.PopStyleColor();
             }
 
-            EurekaParentAttribute? eurekaparents = preset.GetAttribute<EurekaParentAttribute>();
-            if (eurekaparents is not null)
+            if (eurekaParents is not null)
             {
                 ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.HealerGreen);
-                ImGui.TextWrapped($"Part of normal combo{(varientparents.ParentPresets.Length > 1 ? "s" : "")}:");
+                ImGui.TextWrapped($"Part of normal combo{(variantParents.ParentPresets.Length > 1 ? "s" : "")}:");
                 StringBuilder builder = new();
-                foreach (var par in eurekaparents.ParentPresets)
+                foreach (var par in eurekaParents.ParentPresets)
                 {
-                    builder.Insert(0, $"{par.GetAttribute<CustomComboInfoAttribute>().FancyName}");
+                    builder.Insert(0, $"{(Attributes.ContainsKey(par) ? Attributes[par].CustomComboInfo.FancyName : par.GetAttribute<CustomComboInfoAttribute>().FancyName)}");
                     var par2 = par;
                     while (PresetStorage.GetParent(par2) != null)
                     {
                         var subpar = PresetStorage.GetParent(par2);
-                        builder.Insert(0, $"{subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName} -> ");
-                        par2 = subpar!.Value;
+                        if (subpar != null)
+                        {
+                            builder.Insert(0, $"{(Attributes.ContainsKey(subpar.Value) ? Attributes[subpar.Value].CustomComboInfo.FancyName : subpar?.GetAttribute<CustomComboInfoAttribute>().FancyName)} -> ");
+                            par2 = subpar!.Value;
+                        }
 
                     }
 
@@ -199,23 +245,13 @@ namespace XIVSlothCombo.Window.Functions
 
             UserConfigItems.Draw(preset, enabled);
 
-            if (preset == CustomComboPreset.NIN_ST_SimpleMode_BalanceOpener || preset == CustomComboPreset.NIN_ST_AdvancedMode_BalanceOpener)
-            {
-                ImGui.SetCursorPosX(ImGui.GetCursorPosX() + length.Length());
-                if (ImGui.Button($"Image of rotation###ninrtn{i}"))
-                {
-                    Util.OpenLink("https://i.imgur.com/IeP27KF.png");
-                }
-            }
-
             i++;
 
-            var hideChildren = Service.Configuration.HideChildren;
-            var children = presetChildren[preset];
+            var children = presetChildren.ContainsKey(preset) ? presetChildren[preset] : null;
 
-            if (children.Length > 0)
+            if (children != null)
             {
-                if (enabled || !hideChildren)
+                if (enabled || !Service.Configuration.HideChildren)
                 {
                     ImGui.Indent();
 
@@ -244,10 +280,10 @@ namespace XIVSlothCombo.Window.Functions
                                 continue;
                             }
                         }
-
                         else
                         {
                             DrawPreset(childPreset, childInfo, ref i);
+                            continue;
                         }
                     }
 
@@ -263,7 +299,7 @@ namespace XIVSlothCombo.Window.Functions
 
         private static void DrawReplaceAttribute(CustomComboPreset preset)
         {
-            var att = preset.GetReplaceAttribute();
+            var att = Attributes[preset].ReplaceSkill;
             if (att != null)
             {
                 string skills = string.Join(", ", att.ActionNames);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1848,6 +1848,7 @@ namespace XIVSlothCombo.Window.Functions
                     ImGui.Unindent();
                 }
                 UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_ViceOfThorns, "Vice of Thorns", "");
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_Prefulgence, "Prefulgence", "");
             }
 
             if (preset is CustomComboPreset.RDM_ST_MeleeCombo)
@@ -1899,6 +1900,7 @@ namespace XIVSlothCombo.Window.Functions
                     ImGui.Unindent();
                 }
                 UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_ViceOfThorns, "Vice of Thorns", "");
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_Prefulgence, "Prefulgence", "");
             }
 
             if (preset is CustomComboPreset.RDM_AoE_MeleeCombo)

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -2208,9 +2208,6 @@ namespace XIVSlothCombo.Window.Functions
                 }
             }
 
-            if (preset is CustomComboPreset.SCH_AoE_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, SCH.Config.SCH_AoE_LucidOption, "MP Threshold", 150, SliderIncrements.Hundreds);
-
             if (preset is CustomComboPreset.SCH_ST_Heal)
             {
                 UserConfig.DrawAdditionalBoolChoice(SCH.Config.SCH_ST_Heal_Adv, "Advanced Options", "", isConditionalChoice: true);
@@ -2237,7 +2234,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.SCH_ST_Heal_Esuna)
                 UserConfig.DrawSliderInt(0, 100, SCH.Config.SCH_ST_Heal_EsunaOption, "Stop using when below HP %. Set to Zero to disable this check");
 
-            if (preset is CustomComboPreset.SCH_AoE_Heal)
+            if (preset is CustomComboPreset.SCH_AoE_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, SCH.Config.SCH_AoE_Heal_LucidOption, "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SCH_DeploymentTactics)


### PR DESCRIPTION
As per [The Balance FAQ](https://www.thebalanceffxiv.com/jobs/casters/pictomancer/faq/#q2), Holy is a DPS gain in AoE. Adds a feature to include Holy in White to the AoE combo and a slider to choose how many charges to hold on to.